### PR TITLE
Remove version constraint for g4/value-object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php"           : ">=5.6",
         "g4/runner"     : "*",
         "g4/utility"    : "*",
-        "g4/value-object" : "3.*"
+        "g4/value-object" : "*"
     },
     "suggest": {
         "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php"           : ">=5.6",
         "g4/runner"     : "*",
         "g4/utility"    : "*",
-        "g4/value-object" : "2.*"
+        "g4/value-object" : "3.*"
     },
     "suggest": {
         "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server"


### PR DESCRIPTION
This may contains breaking changes, please bump minor or even major version.