### PR TITLE
Improvement: Obfuscate params can be array of callables instead of just an array of fields

### DIFF
--- a/src/Data/Request.php
+++ b/src/Data/Request.php
@@ -72,12 +72,13 @@ class Request extends RequestResponseAbstarct
     {
         \parse_str(\trim(\file_get_contents('php://input')), $rawBodyParams);
 
-        foreach($this->paramsToObfuscate as $key) {
-            if (isset($params[$key])) {
-                $params[$key] = '*****';
+        foreach($this->paramsToObfuscate as $key => $value) {
+            $paramIndex = is_int($key) ? $value : $key;
+            if (isset($params[$paramIndex])) {
+                $params[$paramIndex] = is_callable($value) ? $value($params[$paramIndex]) : '*****';
             }
-            if (is_array($rawBodyParams) && \array_key_exists($key, $rawBodyParams)) {
-                $rawBodyParams[$key] = '_obfuscated_';
+            if (is_array($rawBodyParams) && \array_key_exists($paramIndex, $rawBodyParams)) {
+                $rawBodyParams[$paramIndex] = is_callable($value) ? $value($rawBodyParams[$paramIndex]) : '__obfuscated__';
             }
         }
 


### PR DESCRIPTION
Obfuscate parameters can be used as:

```
$logger = G4\Log\Data\Request();
$logger->setParamsToObfuscate(['cc_number', 'cc_cvv2', 'image', 'media'])
```
or like
```
$logger = G4\Log\Data\Request();
$logger->setParamsToObfuscate([
                'cc_number' => function ($value) {
                    return substr_replace($value, str_repeat('*', 12), 0, -4);
                },
                'cc_cvv2' => function ($value) {
                    return '***';
                },
                'image' => function ($value) {
                    return substr($value, 0, 32) . '...truncated';
                },
                'media' => function ($value) {
                    return substr($value, 0, 32) . '...truncated';
                },
            ])
```