### PR TITLE
Fixed 'timestamp' on TaskerExecution.php to show time when the task i…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "php"             : ">=7.3",
         "ext-json"        : "*",
         "ext-curl"        : "*",
-        "g4/runner"       : ">=0.22.0",
+        "g4/runner"       : ">=0.26.0",
         "g4/utility"      : "*",
         "g4/value-object" : "*",
         "g4/version"      : "^0.0.2",

--- a/src/Adapter/Redis.php
+++ b/src/Adapter/Redis.php
@@ -58,7 +58,6 @@ class Redis extends AdapterAbstract
         } catch (\Exception $exception) {
             error_log ($exception->getMessage(), 0);
         }
-
     }
 
 

--- a/src/AdapterAbstract.php
+++ b/src/AdapterAbstract.php
@@ -27,6 +27,17 @@ abstract class AdapterAbstract implements AdapterInterface
         return $this;
     }
 
+    public function clearData()
+    {
+        // clear all log data except keys _index and _type
+        foreach ($this->data as $key => $value) {
+            if (!in_array($key, ['_index', '_type'])) {
+                unset($this->data[$key]);
+            }
+        }
+        return $this;
+    }
+
     public function beLazy()
     {
         $this->shouldBeLazy = true;

--- a/src/Data/TaskerStart.php
+++ b/src/Data/TaskerStart.php
@@ -11,6 +11,11 @@ class TaskerStart extends LoggerAbstract
     private $options;
 
     /**
+     * @var string
+     */
+    private $type;
+
+    /**
      * @return array
      */
     public function getRawData()
@@ -18,6 +23,7 @@ class TaskerStart extends LoggerAbstract
         $rawData = [
             'id' => $this->getId(),
             'timestamp' => $this->getJsTimestamp(),
+            'type' => $this->type,
             'datetime' => \date('Y-m-d H:i:s'),
             'options' => \json_encode($this->options),
             'hostname' => \gethostname(),
@@ -39,5 +45,10 @@ class TaskerStart extends LoggerAbstract
     {
         $this->options = $options;
         return $this;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
     }
 }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -66,6 +66,11 @@ class Logger
         $this->adapter->saveAppend($data->getRawData());
     }
 
+    public function clearData()
+    {
+        $this->adapter->clearData();
+    }
+
     /**
      * @param mixed $var
      * @param string $tag


### PR DESCRIPTION
Fixed 'timestamp' on TaskerExecution.php to show correct time when the task is triggered.

Populate 'profiler' when exec_time exceeds predefined value (2 seconds) clearData() on AdapterAbstract.php to reset log data when using log with long-running processes (e.g. Tasker)